### PR TITLE
Added ARM Asm and compiler options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ ifcc
 # Outputs
 output
 pld-test-output
+
+# IDE
+.vscode

--- a/compiler/AsmARM.cpp
+++ b/compiler/AsmARM.cpp
@@ -1,0 +1,103 @@
+/*******************************************************************************************
+Créé le : 18 mars 2020
+par : peter
+e-mail : popiette@weaboos.united
+*******************************************************************************************/
+
+using namespace std;
+
+#include "AsmARM.h"
+#include "IR.h"
+
+//------------- public methods ---------------------------------------------------------
+
+void AsmARM::gen_prologue(int size)
+{
+
+	output << "str	fp, [sp, #-4]!" << endl
+		   << "add	fp, sp, #0" << endl
+		   << "sub	sp, sp, #"<< (size + (size % 8))+4 << endl; //this ain't necessary when we no have variable
+		
+}
+
+void AsmARM::gen_epilogue()
+{
+	// to-do : if no return do a "mov	r3, #0"
+	output << "mov	r0, r3" << endl
+		   << "sub	sp, fp, #0" << endl
+		   << "ldr	fp, [sp], #4" << endl
+		   << "bx	lr" << endl;
+}
+
+
+void AsmARM::ldconst(string arg1, string arg2)
+{
+	// Getting x86 assembly code to access variables.
+	arg1 = cfg->IR_reg_to_asm_arm(arg1);
+	arg2 = cfg->IR_reg_to_asm_arm(arg2);
+
+	if (arg2 == "%retval") {
+		output << "ldr	r3, " << arg1 << endl;	
+	} else {
+		output << "mov	r3, " << arg1 << endl;	
+		output << "str	r3, " << arg2 << endl;
+	}
+}
+
+void AsmARM::add(string arg1, string arg2, string arg3)
+{
+	arg1 = cfg->IR_reg_to_asm_arm(arg1);	
+	arg2 = cfg->IR_reg_to_asm_arm(arg2);
+	arg3 = cfg->IR_reg_to_asm_arm(arg3);
+
+	output << "ldr	r2, " << arg1 << endl
+		   << "ldr	r3, " << arg2 << endl
+		   << "add	r3, r3, r2" << endl
+		   << "str	r3, " << arg3 << endl;
+}
+
+void AsmARM::sub(string arg1, string arg2, string arg3)
+{
+	arg1 = cfg->IR_reg_to_asm_arm(arg1);	
+	arg2 = cfg->IR_reg_to_asm_arm(arg2);
+	arg3 = cfg->IR_reg_to_asm_arm(arg3);
+
+	// doing arg3 = arg1 - arg2
+	
+	output << "ldr	r2, " << arg1 << endl
+		   << "ldr	r3, " << arg2 << endl
+		   << "rsb	r3, r3, r2" << endl
+		   << "str	r3, " << arg3 << endl;
+}
+
+void AsmARM::mul(string arg1, string arg2, string arg3)
+{
+	arg1 = cfg->IR_reg_to_asm_arm(arg1);	
+	arg2 = cfg->IR_reg_to_asm_arm(arg2);
+	arg3 = cfg->IR_reg_to_asm_arm(arg3);
+
+	output << "ldr	r2, " << arg1 << endl
+		   << "ldr	r3, " << arg2 << endl
+		   << "mul	r3, r3, r2" << endl
+		   << "str	r3, " << arg3 << endl;
+}
+
+void AsmARM::globl(string name)
+{
+	output << ".globl " << name << endl
+		   << name << ":" << endl;
+}
+
+//------------- Constructor / Destructors ------------------------------------------------
+
+AsmARM::AsmARM(CFG * graph, ostream &out) : cfg(graph), output(out)
+{
+
+}	
+
+//------------- Protected methods ---------------------------------------------------------
+
+string AsmARM::loadVariable(string var)
+{
+	return var;
+}

--- a/compiler/AsmARM.h
+++ b/compiler/AsmARM.h
@@ -4,42 +4,44 @@ par : pierre
 e-mail :
 ******************************************************************/
 
-#if ! defined ( ASM_H )
-#define ASM_H
+#if ! defined ( ASMARM_H )
+#define ASMARM_H
 
 #include <iostream>
 #include <string>
+
+#include "Asm.h"
+
 
 class CFG;
 //-----------------------------------------------------------------
 
 // class used for converting IR instructions to x86 assembly
-class Asm
+class AsmARM : public Asm
 {
 	public:
 
 	//----- public methods -----
-		virtual void gen_prologue(int size) = 0;
-		virtual void gen_epilogue() = 0;
+		void gen_prologue(int size);
+		void gen_epilogue();
 
-		virtual void ldconst(std::string arg1, std::string arg2) = 0;
+		void ldconst(std::string arg1, std::string arg2);
 		
 		// add arg1 and arg2, and store the result into arg3.
-		virtual void add(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void add(std::string arg1, std::string arg2, std::string arg3);
 
 		// sub arg1 and arg2, and store the result into arg3.
-		virtual void sub(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void sub(std::string arg1, std::string arg2, std::string arg3);
 
 		// mul arg1 and arg2, and store the result into arg3.
-		virtual void mul(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void mul(std::string arg1, std::string arg2, std::string arg3);
 		
-		// TODO : check if the globl exist in ARM and MSP430 ABI.
-		virtual void globl(std::string name) = 0;
+		// TODO : check if the globl exist in ARM and MSP430 ABI. It exists in ARM
+		void globl(std::string name);
 
 	//---- overloaded operators ----
 	//--- Constructors / Destructor ---
-		Asm(){};
-		Asm(CFG * graph, std::ostream &out){};
+		AsmARM(CFG * graph, std::ostream &out);
 
 	protected:
 	//----- protected methods -----
@@ -48,12 +50,12 @@ class Asm
 		// it can be used for calculation.
 		// It returns the register in wich the variable has
 		// been put. (%eax, usually).
-		virtual std::string loadVariable(std::string var) = 0;	
+		std::string loadVariable(std::string var);	
 	//----- protected attributes -----
-		// CFG * cfg;
-		// std::ostream &output;
+		CFG * cfg;
+		std::ostream &output;
 
 
 };
 
-#endif // ! defined ( ASM_H )
+#endif // ! defined ( ASMARM_H )

--- a/compiler/Asmx86.cpp
+++ b/compiler/Asmx86.cpp
@@ -6,19 +6,19 @@ e-mail :
 
 using namespace std;
 
-#include "Asm.h"
+#include "Asmx86.h"
 #include "IR.h"
 
 //------------- public methods ---------------------------------------------------------
 
-void Asm::gen_prologue(int size)
+void Asmx86::gen_prologue(int size)
 {
 	output << "pushq %rbp" << endl
 		   << "movq %rsp, %rbp" << endl
 		   << "subq $" << size << ", %rsp" << endl;
 }
 
-void Asm::gen_epilogue()
+void Asmx86::gen_epilogue()
 {
 	output << "movq %rbp, %rsp" << endl
 		   << "popq %rbp" << endl
@@ -26,40 +26,40 @@ void Asm::gen_epilogue()
 }
 
 
-void Asm::ldconst(string arg1, string arg2)
+void Asmx86::ldconst(string arg1, string arg2)
 {
 	// Getting x86 assembly code to access variables.
 	arg1 = loadVariable(arg1);
-	arg2 = cfg->IR_reg_to_asm(arg2);
+	arg2 = cfg->IR_reg_to_asm_x86(arg2);
 
 	output << "movl " << arg1 << ", " << arg2 << endl;	
 }
 
-void Asm::add(string arg1, string arg2, string arg3)
+void Asmx86::add(string arg1, string arg2, string arg3)
 {
 	arg1 = loadVariable(arg1);	
-	arg3 = cfg->IR_reg_to_asm(arg3);
+	arg3 = cfg->IR_reg_to_asm_x86(arg3);
 	output << "movl " << arg1 << ", " << arg3 << endl;	
 	
 	arg2 = loadVariable(arg2);
 	output << "addl " << arg2 << ", " << arg3 << endl;
 }
 
-void Asm::sub(string arg1, string arg2, string arg3)
+void Asmx86::sub(string arg1, string arg2, string arg3)
 {
 	arg1 = loadVariable(arg1);		
-	arg3 = cfg->IR_reg_to_asm(arg3);
+	arg3 = cfg->IR_reg_to_asm_x86(arg3);
 	output << "movl " << arg1 << ", " << arg3 << endl;
 
 	arg2 = loadVariable(arg2);
 	output << "subl " << arg2 << ", " << arg3 << endl;
 }
 
-void Asm::mul(string arg1, string arg2, string arg3)
+void Asmx86::mul(string arg1, string arg2, string arg3)
 {
-	arg1 = cfg->IR_reg_to_asm(arg1);	
-	arg2 = cfg->IR_reg_to_asm(arg2);
-	arg3 = cfg->IR_reg_to_asm(arg3);
+	arg1 = cfg->IR_reg_to_asm_x86(arg1);	
+	arg2 = cfg->IR_reg_to_asm_x86(arg2);
+	arg3 = cfg->IR_reg_to_asm_x86(arg3);
 	
 	output << "movl " << arg1 << ", " << "%eax" << endl;
 	output << "movl " << arg2 << ", " << "%ebx" << endl;
@@ -67,7 +67,7 @@ void Asm::mul(string arg1, string arg2, string arg3)
 	output << "movl %eax, " << arg3 << endl;
 }
 
-void Asm::globl(string name)
+void Asmx86::globl(string name)
 {
 	output << ".globl " << name << endl
 		   << name << ":" << endl;
@@ -75,16 +75,16 @@ void Asm::globl(string name)
 
 //------------- Constructor / Destructors ------------------------------------------------
 
-Asm::Asm(CFG * graph, ostream &out) : cfg(graph), output(out)
+Asmx86::Asmx86(CFG * graph, ostream &out) : cfg(graph), output(out)
 {
 
 }	
 
 //------------- Protected methods ----------------------------------------------
 
-string Asm::loadVariable(string var)
+string Asmx86::loadVariable(string var)
 {
-	string asm_arg = cfg->IR_reg_to_asm(var);
+	string asm_arg = cfg->IR_reg_to_asm_x86(var);
 	if(asm_arg[0] != '$')
 	// asm_arg is not a constant, it needs to be put in a register to
 	// be available for computation.

--- a/compiler/Asmx86.h
+++ b/compiler/Asmx86.h
@@ -4,42 +4,44 @@ par : pierre
 e-mail :
 ******************************************************************/
 
-#if ! defined ( ASM_H )
-#define ASM_H
+#if ! defined ( ASMx86_H )
+#define ASMx86_H
 
 #include <iostream>
 #include <string>
+
+#include "Asm.h"
+
 
 class CFG;
 //-----------------------------------------------------------------
 
 // class used for converting IR instructions to x86 assembly
-class Asm
+class Asmx86 : public Asm
 {
 	public:
 
 	//----- public methods -----
-		virtual void gen_prologue(int size) = 0;
-		virtual void gen_epilogue() = 0;
+		void gen_prologue(int size);
+		void gen_epilogue();
 
-		virtual void ldconst(std::string arg1, std::string arg2) = 0;
+		void ldconst(std::string arg1, std::string arg2);
 		
 		// add arg1 and arg2, and store the result into arg3.
-		virtual void add(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void add(std::string arg1, std::string arg2, std::string arg3);
 
 		// sub arg1 and arg2, and store the result into arg3.
-		virtual void sub(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void sub(std::string arg1, std::string arg2, std::string arg3);
 
 		// mul arg1 and arg2, and store the result into arg3.
-		virtual void mul(std::string arg1, std::string arg2, std::string arg3) = 0;
+		void mul(std::string arg1, std::string arg2, std::string arg3);
 		
-		// TODO : check if the globl exist in ARM and MSP430 ABI.
-		virtual void globl(std::string name) = 0;
+		// TODO : check if the globl exist in ARM and MSP430 ABI. It exists in ARM
+		void globl(std::string name);
 
 	//---- overloaded operators ----
 	//--- Constructors / Destructor ---
-		Asm(){};
-		Asm(CFG * graph, std::ostream &out){};
+		Asmx86(CFG * graph, std::ostream &out);
 
 	protected:
 	//----- protected methods -----
@@ -48,12 +50,12 @@ class Asm
 		// it can be used for calculation.
 		// It returns the register in wich the variable has
 		// been put. (%eax, usually).
-		virtual std::string loadVariable(std::string var) = 0;	
+		std::string loadVariable(std::string var);	
 	//----- protected attributes -----
-		// CFG * cfg;
-		// std::ostream &output;
+		CFG * cfg;
+		std::ostream &output;
 
 
 };
 
-#endif // ! defined ( ASM_H )
+#endif // ! defined ( ASMx86_H )

--- a/compiler/IR.h
+++ b/compiler/IR.h
@@ -9,6 +9,8 @@
 #include <map>
 
 #include "Asm.h"
+#include "Asmx86.h"
+#include "AsmARM.h"
 #include "Errors.h"
 // Declarations from the parser -- replace with your own
 
@@ -198,7 +200,7 @@ class BasicBlock {
  */
 class CFG {
  public:
-	CFG(Ast* ast);
+	CFG(Ast* ast, std::string asm_choice);
 
 	
 	void add_bb(BasicBlock* bb); 
@@ -218,7 +220,9 @@ class CFG {
 	
 	// Helper method : inputs a IR reg or input variable, and return
 	// e.g. "-24(%rbp)" for the proper value of 24 
-	std::string IR_reg_to_asm(std::string reg);
+	std::string IR_reg_to_asm_x86(std::string reg);
+	std::string IR_reg_to_asm_arm(std::string reg);
+	std::string IR_reg_to_asm_msp430(std::string reg);
 	
 	// symbol table methods
 	
@@ -261,7 +265,7 @@ class CFG {
 	int nextBBnumber; /**< just for naming */
 	
 	std::vector <BasicBlock*> bbs; /**< all the basic blocks of this CFG*/
-	Asm toasm; // asm converter.
+	Asm* toasm; // asm converter.
 
 	std::list <std::string> varUnused; /**Store the variable unused to trigger warnings at the end of the compilation */
 };

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -16,7 +16,8 @@ all: ifcc
 ifcc: dirs antlr  main.cpp visitor.cpp visitor.h IR.cpp IR.h
 	$(CC) $(CCARGS) main.cpp  -o $(OUTPUT)/main.o 
 	$(CC) $(CCARGS) IR.cpp -o $(OUTPUT)/IR.o
-	$(CC) $(CCARGS) Asm.cpp -o $(OUTPUT)/Asm.o
+	$(CC) $(CCARGS) Asmx86.cpp -o $(OUTPUT)/Asmx86.o
+	$(CC) $(CCARGS) AsmARM.cpp -o $(OUTPUT)/AsmARM.o
 	$(CC) $(CCARGS) Ast.cpp -o $(OUTPUT)/Ast.o
 	$(CC) $(CCARGS) Errors.cpp -o $(OUTPUT)/Errors.o
 	$(CC) $(CCARGS) $(GENERATED)/ifccBaseVisitor.cpp -o $(OUTPUT)/ifccBaseVisitor.o 
@@ -24,7 +25,7 @@ ifcc: dirs antlr  main.cpp visitor.cpp visitor.h IR.cpp IR.h
 	$(CC) $(CCARGS) $(GENERATED)/ifccVisitor.cpp -o $(OUTPUT)/ifccVisitor.o 
 	$(CC) $(CCARGS) $(GENERATED)/ifccParser.cpp -o $(OUTPUT)/ifccParser.o 
 	$(CC) $(CCARGS) visitor.cpp -o $(OUTPUT)/visitor.o 
-	$(CC) $(LDARGS) $(OUTPUT)/main.o $(OUTPUT)/IR.o $(OUTPUT)/Asm.o $(OUTPUT)/Ast.o $(OUTPUT)/Errors.o $(OUTPUT)/ifccBaseVisitor.o $(OUTPUT)/ifccLexer.o $(OUTPUT)/ifccVisitor.o $(OUTPUT)/ifccParser.o $(OUTPUT)/visitor.o $(ANTLR4_LIBDIR)/libantlr4-runtime.a -o ifcc
+	$(CC) $(LDARGS) $(OUTPUT)/main.o $(OUTPUT)/IR.o $(OUTPUT)/Asmx86.o $(OUTPUT)/AsmARM.o $(OUTPUT)/Ast.o $(OUTPUT)/Errors.o $(OUTPUT)/ifccBaseVisitor.o $(OUTPUT)/ifccLexer.o $(OUTPUT)/ifccVisitor.o $(OUTPUT)/ifccParser.o $(OUTPUT)/visitor.o $(ANTLR4_LIBDIR)/libantlr4-runtime.a -o ifcc
 
 antlr: $(GRAMMAR)
 	$(ANTLR4_BINDIR)/antlr4 -visitor -no-listener -Dlanguage=Cpp -o $(GENERATED) $(GRAMMAR)

--- a/compiler/main.cpp
+++ b/compiler/main.cpp
@@ -18,10 +18,17 @@ using namespace std;
 
 int main(int argn, const char **argv) {
 	int ret = 0;
+	std::string asm_choice = "-x86";
 	stringstream in;
-	if (argn==2) {
-		ifstream lecture(argv[1]);
+	if (argn>=2) {
+		int pathIndex = 1;
+		if (argn==3) {
+			pathIndex = 2;
+			asm_choice = argv[1];
+		}
+		ifstream lecture(argv[pathIndex]);
 		in << lecture.rdbuf();
+
 	}
 	ANTLRInputStream input(in.str());
 	ifccLexer lexer(&input);
@@ -47,7 +54,7 @@ int main(int argn, const char **argv) {
 		return parserSyntaxError;
 	}
 
-	CFG * cfg = new CFG(nullptr);
+	CFG * cfg = new CFG(nullptr, asm_choice);
 	Visitor visitor(cfg);
 
 	try

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,2 +1,2 @@
 cd ..
-docker run --rm -v $(pwd):/work eguerin/antlr4cpp bash -c "cd /work/tests ; chmod 755 pld-wrapper.sh; python3 pld-test.py tests/Init/"
+docker run --rm -v $(pwd):/work eguerin/antlr4cpp bash -c "cd /work/tests ; chmod 755 pld-wrapper.sh; python3 pld-test.py tests/Init/; python3 pld-test.py tests/Variables/; python3 pld-test.py tests/VerifsStatiques/"


### PR DESCRIPTION
# Changes :
- Modified project structure to make Asm into abstract base class
- Changed old Asm class into Asmx86 child class
- Created new AsmARM child class

# New features
- Create ARM assembly code
- Choose type of assembly code :
- E.g :
`ifcc -arm hello_world.c`
- Options : -arm, -msp430, -x86 (default if no option provided)